### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
   "author": "Mozilla",
   "license": "MPL-2.0",
   "dependencies": {
-    "autoprefixer": "^6.0.3",
-    "boom": "^2.9.0",
+    "autoprefixer": "6.0.3",
+    "boom": "2.9.0",
     "country-data": "0.0.23",
-    "good": "^6.3.0",
-    "good-console": "^5.0.3",
-    "habitat": "^3.1.2",
-    "hapi": "^10.0.0",
-    "hoek": "^2.16.2",
-    "inert": "^3.0.1",
-    "joi": "^6.7.1",
-    "postcss": "^5.0.6",
-    "request": "^2.62.0"
+    "good": "6.4.0",
+    "good-console": "5.1.0",
+    "habitat": "3.1.2",
+    "hapi": "10.4.0",
+    "hoek": "2.16.3",
+    "inert": "3.1.0",
+    "joi": "6.9.0",
+    "postcss": "5.0.8",
+    "request": "2.64.0"
   },
   "engines": {
     "node": "^4.0.0"


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/) – they’re always in a state you know about.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>