### PR TITLE
Temporary removal of FB share button from data privacy day page.

### DIFF
--- a/public/stay-secure/thank-you/index.html
+++ b/public/stay-secure/thank-you/index.html
@@ -24,12 +24,7 @@
         </h2>
         <div class="container">
           <div class="row">
-            <div class="half" id="facebook">
-              <a href="http://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fpetitions.mozilla.org%2Fstay-secure" target="_blank">
-              <i class="fa fa-facebook fa-5x"></i>
-              <p>facebook</p></a>
-            </div>
-            <div class="half" id="twitter">
+            <div id="twitter">
               <a href="http://twitter.com/share?url=http%3A%2F%2Fmzl.la%2Fupdate&amp;hashtags=DPD2016,PrivacyAware&amp;text=Help%20safeguard%20privacy%2Bsecurity%20by%20updating%20your%20software.%20I%20just%20did%20with%20%40mozilla%E2%80%99s%20help%3A" target="_blank">
               <i class="fa fa-twitter fa-5x"></i>
               <p>twitter</p>


### PR DESCRIPTION
- Will re-add FB button when server/scraping issues are sorted.

**Should merge and push to production only if #113 is not resolved by 1/28.**